### PR TITLE
公演一覧で一日目と二日目の日程がずれているのを直す

### DIFF
--- a/components/events/ShowAllEventsButton.vue
+++ b/components/events/ShowAllEventsButton.vue
@@ -159,8 +159,8 @@ export default Vue.extend({
       second_day_events: [],
       other_day_events: [],
       date: {
-        '1': '9/16',
-        '2': '9/17',
+        '1': '9/14',
+        '2': '9/15',
       },
     }
   },


### PR DESCRIPTION

<img width="509" alt="スクリーンショット 2024-05-04 23 28 23" src="https://github.com/hibiya-itchief/quaint-wa/assets/74809407/1627c796-c68d-43bf-a8a0-293faf97cf2f">

これを9/14と9/15に直した